### PR TITLE
Handling disabled/hidden fields

### DIFF
--- a/carto54.py
+++ b/carto54.py
@@ -190,16 +190,15 @@ class Carto54:
             raise Exception("Destination must be an existing folder")
         return directory
 
-    def generate_output(self):
+    def update_destination(self, output):
+        output.directory = self.get_destination_directory()
+
+    def generate_output(self, output):
         """
-        Create and fill the output file
+        Save the output
         """
-        layers = QgsProject.instance().mapLayers().values()
-        directory = self.get_destination_directory()
-        output = Output(directory)
-        output.generate_structure(layers)
         print(output.__dict__)
-        output.save()
+        # output.save()
         self.dlg.close()
 
     def run(self):
@@ -217,11 +216,21 @@ class Carto54:
         # Default values
         default_directory = QgsProject.instance().absolutePath()
 
+        # Getting layers
+        layers = QgsProject.instance().mapLayers().values()
+
+        # Creating Output instance
+        output = Output(default_directory)
+        output.generate_structure(layers)
+
         # Setting default values
         self.dlg.ipt_dest.setText(default_directory)
 
+        # Listening destination input changes
+        self.dlg.ipt_dest.editingFinished.connect(lambda: self.update_destination(output))
+
         # Listening clicks on buttons
         self.dlg.btn_cancel.clicked.connect(self.dlg.close)
-        self.dlg.btn_generate.clicked.connect(self.generate_output)
+        self.dlg.btn_generate.clicked.connect(lambda: self.generate_output(output))
 
 

--- a/carto54.py
+++ b/carto54.py
@@ -33,6 +33,7 @@ from .carto54_dialog import Carto54Dialog
 import os.path
 
 from .utils.output import Output
+from .utils.table import fill_table
 
 
 class Carto54:
@@ -193,6 +194,14 @@ class Carto54:
     def update_destination(self, output):
         output.directory = self.get_destination_directory()
 
+    def fill_display_table(self, output):
+        fields = []
+        categories = output.structure["form"]
+        for category in categories:
+            fields.extend(categories[category])
+        fill_table(self.dlg.tw_display, fields)
+
+
     def generate_output(self, output):
         """
         Save the output
@@ -225,6 +234,10 @@ class Carto54:
 
         # Setting default values
         self.dlg.ipt_dest.setText(default_directory)
+
+        # Config display table
+        self.dlg.tw_display.setRowCount(output.get_fields_count())
+        self.fill_display_table(output)
 
         # Listening destination input changes
         self.dlg.ipt_dest.editingFinished.connect(lambda: self.update_destination(output))

--- a/carto54_dialog_base.ui
+++ b/carto54_dialog_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>150</height>
+    <width>400</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -34,7 +34,7 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
@@ -49,6 +49,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="btn_dest">
+       <property name="maximumSize">
+        <size>
+         <width>40</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="cursor">
         <cursorShape>PointingHandCursor</cursorShape>
        </property>
@@ -61,6 +67,50 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="lbl_display">
+       <property name="text">
+        <string>Display</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTableWidget" name="tw_display">
+       <column>
+        <property name="text">
+         <string>Layer</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Disabled</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Hidden</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/utils/form.py
+++ b/utils/form.py
@@ -11,11 +11,13 @@ def field_config(field):
     :return: Dict
     """
     widget = field.editorWidgetSetup()
+    options = widget.config()
+    options.update({"disabled": False, "hidden": False})
     return dict(
         name=field.name(),
         alias=field.alias(),
         type=widget.type(),
-        options=widget.config(),
+        options=options,
         default=field.defaultValueDefinition().expression()
     )
 

--- a/utils/output.py
+++ b/utils/output.py
@@ -17,14 +17,19 @@ class Output:
                 "inputDate": [],
                 "inputRange": [],
                 "textArea": [],
-                "selectBox": [],
-                "disabled": [],
-                "hidden": []
+                "selectBox": []
             }
         }
 
     def get_path(self):
         return "{}/{}".format(self.directory, self.entrypoint)
+
+    def get_fields_count(self):
+        res = 0
+        categories = self.structure["form"]
+        for c in categories:
+            res += len(categories[c])
+        return res
 
     def add_inputText(self, config):
         inputText_list = self.structure["form"]["inputText"]

--- a/utils/output.py
+++ b/utils/output.py
@@ -24,35 +24,52 @@ class Output:
     def get_path(self):
         return "{}/{}".format(self.directory, self.entrypoint)
 
+    def get_categories(self):
+        return self.structure["form"]
+    
     def get_fields_count(self):
-        res = 0
-        categories = self.structure["form"]
+        count = 0
+        categories = self.get_categories()
         for c in categories:
-            res += len(categories[c])
-        return res
+            count += len(categories[c])
+        return count
+    
+    def get_fields(self):
+        fields = []
+        categories = self.get_categories()
+        for c in categories:
+            fields.extend(categories[c])
+        return fields
+
+    def find_field_by_name(self, name):
+        fields = self.get_fields()
+        for f in fields:
+            if f["name"] == name:
+                return f
+        return
 
     def add_inputText(self, config):
-        inputText_list = self.structure["form"]["inputText"]
+        inputText_list = self.get_categories()["inputText"]
         inputText_list.append(config)
 
     def add_inputNumber(self, config):
-        inputNumber_list = self.structure["form"]["inputNumber"]
+        inputNumber_list = self.get_categories()["inputNumber"]
         inputNumber_list.append(config)
 
     def add_inputDate(self, config):
-        inputDate_list = self.structure["form"]["inputDate"]
+        inputDate_list = self.get_categories()["inputDate"]
         inputDate_list.append(config)
 
     def add_inputRange(self, config):
-        inputRange_list = self.structure["form"]["inputRange"]
+        inputRange_list = self.get_categories()["inputRange"]
         inputRange_list.append(config)
 
     def add_textArea(self, config):
-        textArea_list = self.structure["form"]["textArea"]
+        textArea_list = self.get_categories()["textArea"]
         textArea_list.append(config)
 
     def add_selectBox(self, config):
-        selectBox_list = self.structure["form"]["selectBox"]
+        selectBox_list = self.get_categories()["selectBox"]
         selectBox_list.append(config)
     
     def add_config(self, config):

--- a/utils/output.py
+++ b/utils/output.py
@@ -10,7 +10,6 @@ class Output:
         """
         self.directory = directory
         self.entrypoint = "app.config.json"
-        self.path = "{}/{}".format(directory, self.entrypoint)
         self.structure = {
             "form": {
                 "inputText": [],
@@ -18,9 +17,14 @@ class Output:
                 "inputDate": [],
                 "inputRange": [],
                 "textArea": [],
-                "selectBox": []
+                "selectBox": [],
+                "disabled": [],
+                "hidden": []
             }
         }
+
+    def get_path(self):
+        return "{}/{}".format(self.directory, self.entrypoint)
 
     def add_inputText(self, config):
         inputText_list = self.structure["form"]["inputText"]
@@ -76,12 +80,13 @@ class Output:
         for c in configs:
             self.add_config(c)
 
+
     def save(self):
         """
         Parse structure into json then create the output file and write inside
         """
         parsed_structure = json.dumps(self.structure)
-        f = open(self.path, "w+")
+        f = open(self.get_path(), "w+")
         f.write(parsed_structure)
         f.close()
 

--- a/utils/table.py
+++ b/utils/table.py
@@ -1,16 +1,23 @@
-from qgis.PyQt.QtWidgets import QLabel, QCheckBox
+from qgis.PyQt.QtWidgets import QTableWidgetItem
+from qgis.PyQt.QtCore import Qt
 
 def create_label_item(title):
-    return QLabel(title)
+    item = QTableWidgetItem(title)
+    item.setTextAlignment(Qt.AlignCenter)
+    return item
 
-def create_checkbox_item():
-    return QCheckBox()
+def create_checkbox_item(attribute):
+    item = QTableWidgetItem()
+    item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+    item.setCheckState(Qt.Unchecked)
+    item.setData(1, attribute)
+    return item
 
 def create_row(field):
     return dict(
         label=create_label_item(field["name"]),
-        checkbox_hidden=create_checkbox_item(),
-        checkbox_disabled=create_checkbox_item()
+        checkbox_hidden=create_checkbox_item('hidden'),
+        checkbox_disabled=create_checkbox_item('disabled')
     )
 
 
@@ -21,6 +28,6 @@ def create_rows(fields):
 def fill_table(table, fields):
     rows = create_rows(fields)
     for index, row in enumerate(rows):
-        table.setCellWidget(index, 0, row["label"])
-        table.setCellWidget(index, 1, row["checkbox_disabled"])
-        table.setCellWidget(index, 2, row["checkbox_hidden"])
+        table.setItem(index, 0, row["label"])
+        table.setItem(index, 1, row["checkbox_disabled"])
+        table.setItem(index, 2, row["checkbox_hidden"])

--- a/utils/table.py
+++ b/utils/table.py
@@ -1,0 +1,26 @@
+from qgis.PyQt.QtWidgets import QLabel, QCheckBox
+
+def create_label_item(title):
+    return QLabel(title)
+
+def create_checkbox_item():
+    return QCheckBox()
+
+def create_row(field):
+    return dict(
+        label=create_label_item(field["name"]),
+        checkbox_hidden=create_checkbox_item(),
+        checkbox_disabled=create_checkbox_item()
+    )
+
+
+def create_rows(fields):
+    return list(map(lambda f: create_row(f), fields))
+
+
+def fill_table(table, fields):
+    rows = create_rows(fields)
+    for index, row in enumerate(rows):
+        table.setCellWidget(index, 0, row["label"])
+        table.setCellWidget(index, 1, row["checkbox_disabled"])
+        table.setCellWidget(index, 2, row["checkbox_hidden"])


### PR DESCRIPTION
You can now use the plugin to select fields that will be hidden/disabled in the Form component of the Carto54 Web app

## Usage

The plugin's UI now includes a table, listing available fields (from current project layers).

Each row is composed of 3 cells : `Layer`, `Disabled` and `Hidden`. Those  two last are checkboxes that can be used to indicate if you want the associated field to be disabled or hidden.

## Output

This feature adds 2 attributes into each field's options : `hidden` and `disabled`.