### PR TITLE
Utils - Form - Formatting field's options attribute

### DIFF
--- a/utils/form.py
+++ b/utils/form.py
@@ -2,6 +2,32 @@
 Utils functions to retrieve data from QGIS attributes from
 """
 
+def format_map(widget_map):
+    """
+    Returns a JSON-like version of a ValueMap widget's map option
+    :param widget_map: Dict - The Valuemap to format
+    :return: List
+    """
+    res = []
+    for option in widget_map:
+        key = list(option.keys())[0]
+        val = option[key]
+        res.append({"text": key, "value": val})
+    return res
+
+def field_options(widget):
+    """
+    Returns a formatted options attribute from a widget
+    :param widget: QgsEditorWidgetSetup - A field's widget
+    :return: Dict
+    """
+    options, widget_type, widget_config = dict(), widget.type(), widget.config()
+    options.update(widget_config)
+    options.update({"disabled": False, "hidden": False})
+    if widget_type == "ValueMap":
+        formatted_map = format_map(widget_config["map"])
+        options.update({"map": formatted_map})
+    return options
 
 
 def field_config(field):
@@ -11,8 +37,7 @@ def field_config(field):
     :return: Dict
     """
     widget = field.editorWidgetSetup()
-    options = widget.config()
-    options.update({"disabled": False, "hidden": False})
+    options = field_options(widget)
     return dict(
         name=field.name(),
         alias=field.alias(),


### PR DESCRIPTION
Now we can format the way field option will be rendered.
Here we are formatting the map attribute of a ValueMap widget in order to make it easier to use within the Web app